### PR TITLE
Add maven-integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.origamilabs.library</groupId>
+    <artifactId>StaggeredGridView</artifactId>
+    <version>1.0</version>
+    <name>StaggeredGridView</name>
+    <packaging>apklib</packaging>
+
+    <properties>
+        <java.version>1.6</java.version>
+    </properties>
+
+    <!--<repositories>-->
+        <!--<repository>-->
+            <!--<id>my-repo</id>-->
+            <!--<name>custom_lib</name>-->
+            <!--<url>http://x.oudar.free.fr/maven2</url>-->
+            <!--</repository>-->
+        <!--</repositories>-->
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.android</groupId>
+            <artifactId>android</artifactId>
+            <scope>provided</scope>
+            <version>4.1.1.4</version>
+        </dependency>
+        <dependency>
+            <groupId>android.support</groupId>
+            <artifactId>compatibility-v4</artifactId>
+            <version>11</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src</sourceDirectory>
+
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.jayway.maven.plugins.android.generation2</groupId>
+                <artifactId>android-maven-plugin</artifactId>
+                <version>3.4.1</version>
+                <configuration>
+                    <sdk>
+                        <platform>16</platform>
+                    </sdk>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.jayway.maven.plugins.android.generation2</groupId>
+                <artifactId>android-maven-plugin</artifactId>
+                <version>3.4.1</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <nativeLibrariesDirectory>ignored</nativeLibrariesDirectory>
+                </configuration>
+            </plugin>
+
+        </plugins>
+
+    </build>
+</project>


### PR DESCRIPTION
Then simply run `maven clean package` to generate the apk.

Need extra dependency to artifact android.support:compatibility-v4:11 because
of usage of SparseArrayCompat (official com.google.android:support-v4:11 is
not available in the central naven repository). To get this dependency, use
the github project maven-android-sdk-deployer
(https://github.com/mosabua/maven-android-sdk-deployer).
