### PR TITLE
Fix a bug and add an improvement

### DIFF
--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -3,5 +3,6 @@
     <declare-styleable name="StaggeredGridView">
         <attr name="drawSelectorOnTop" format="boolean" />
         <attr name="numColumns" format="integer" />
+        <attr name="itemMargin" format="dimension" />
     </declare-styleable>
 </resources>

--- a/src/com/origamilabs/library/views/StaggeredGridView.java
+++ b/src/com/origamilabs/library/views/StaggeredGridView.java
@@ -311,6 +311,7 @@ public class StaggeredGridView extends ViewGroup {
         	TypedArray a=getContext().obtainStyledAttributes( attrs, R.styleable.StaggeredGridView);
             mColCount = a.getInteger(R.styleable.StaggeredGridView_numColumns, 2);
             mDrawSelectorOnTop = a.getBoolean(R.styleable.StaggeredGridView_drawSelectorOnTop, false);
+            mItemMargin = (int) a.getDimension(R.styleable.StaggeredGridView_itemMargin, 0);
         }else{
         	mColCount = 2;
         	mDrawSelectorOnTop = false;

--- a/src/com/origamilabs/library/views/StaggeredGridView.java
+++ b/src/com/origamilabs/library/views/StaggeredGridView.java
@@ -2106,7 +2106,7 @@ public class StaggeredGridView extends ViewGroup {
             super(in);
             firstId = in.readLong();
             position = in.readInt();
-            in.readIntArray(topOffsets);
+            in.createIntArray(topOffsets);
             in.readTypedList(mapping, ColMap.CREATOR);
             
         }


### PR DESCRIPTION
Here are two small commits:
- the first one allows modifying the item margin from XML
- the second one fixes a bug: when the activity is recreated after being killed for memory reasons, there was a crash.

The second bullet covers the following use case: if you load the activity with the SGV, open a sub-activity, and switch to another app. Back from the main app after some time (so that it is killed by Android), you're on the sub-activity. Press the back button, boom!
