### PR TITLE
Adapter null check on every access in onTouchEvent()

### DIFF
--- a/src/com/origamilabs/library/views/StaggeredGridView.java
+++ b/src/com/origamilabs/library/views/StaggeredGridView.java
@@ -457,7 +457,8 @@ public class StaggeredGridView extends ViewGroup {
                 mActivePointerId = MotionEventCompat.getPointerId(ev, 0);
                 mTouchRemainderY = 0;
 
-                if(mTouchMode != TOUCH_MODE_FLINGING && !mDataChanged && motionPosition >= 0 && getAdapter().isEnabled(motionPosition)){
+                if(mTouchMode != TOUCH_MODE_FLINGING && !mDataChanged && motionPosition >= 0
+                    && mAdapter != null && mAdapter.isEnabled(motionPosition)) {
                 	mTouchMode = TOUCH_MODE_DOWN;
 
                 	mBeginClick = true;
@@ -576,7 +577,7 @@ public class StaggeredGridView extends ViewGroup {
                                             mPendingCheckForTap : mPendingCheckForLongPress);
                                 }
 
-                                if (!mDataChanged && mAdapter.isEnabled(motionPosition)) {
+                                if (!mDataChanged && mAdapter != null && mAdapter.isEnabled(motionPosition)) {
                                     mTouchMode = TOUCH_MODE_TAP;
 
                                     layoutChildren(mDataChanged);
@@ -609,7 +610,7 @@ public class StaggeredGridView extends ViewGroup {
                                     mTouchMode = TOUCH_MODE_REST;
                                 }
                                 return true;
-                            } else if (!mDataChanged && mAdapter.isEnabled(motionPosition)) {
+                            } else if (!mDataChanged && mAdapter != null && mAdapter.isEnabled(motionPosition)) {
                                 performClick.run();
                             }
                         }


### PR DESCRIPTION
A previous pull request performed a null check only in one of the three accesses to the instance variable 'mAdapter' in the onTouchEvent() method, which can be null when a touch event occurs.
