### PR TITLE
Accessing local variable before nullcheck in getFirstChildAtColumn(int)

### DIFF
--- a/src/com/origamilabs/library/views/StaggeredGridView.java
+++ b/src/com/origamilabs/library/views/StaggeredGridView.java
@@ -1321,11 +1321,9 @@ public class StaggeredGridView extends ViewGroup {
     	if(this.getChildCount() > column){
     		for(int i = 0; i<this.mColCount; i++){
     			final View child = getChildAt(i);
-    			final int left = child.getLeft();
 
-
-    			if(child!=null){
-
+    			if(child!=null) {
+    				final int left = child.getLeft();
         			int col = 0;
 
         			// determine the column by cycling widths


### PR DESCRIPTION
The local variable 'child' is accessed right before a null check (also reported by static analyzer tool FindBugs).
